### PR TITLE
[glib-networking] Depend on gettext instead of intltool. JB#61290

### DIFF
--- a/rpm/glib-networking.spec
+++ b/rpm/glib-networking.spec
@@ -11,7 +11,7 @@ Source0:    %{name}-%{version}.tar.bz2
 BuildRequires:  pkgconfig(glib-2.0) >= 2.60.0
 BuildRequires:  pkgconfig(gio-2.0)
 BuildRequires:  pkgconfig(openssl)
-BuildRequires:  intltool
+BuildRequires:  gettext
 BuildRequires:  ca-certificates
 BuildRequires:  meson
 


### PR DESCRIPTION
Usage switched in 2016. Worked because intltool depends on gettext.